### PR TITLE
Melhorias na documentação do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,35 @@
 [![Build Status](https://travis-ci.org/williamgueiros/Brcpfcnpj.svg?branch=master)](https://travis-ci.org/williamgueiros/Brcpfcnpj)
 [![Inline docs](http://inch-ci.org/github/williamgueiros/Brcpfcnpj.svg?branch=master)](http://inch-ci.org/github/williamgueiros/Brcpfcnpj)
 
-#Brcpfcnpj
+# Brcpfcnpj
 
-Link para [documentação](http://hexdocs.pm/brcpfcnpj/).
+Coleção de funções para validação e formatação de CPF e CNPJ. Veja a
+[documentação online](http://hexdocs.pm/brcpfcnpj/).
 
-Caso utilize elixir < 1.2 utilize a versão 0.0.11, [maiores informacoes](https://github.com/williamgueiros/Brcpfcnpj/issues/5)  
+## Como usar
 
+Adicione ao `mix.exs` do seu projeto:
 
-##Validar Cpf/Cnpj
+```elixir
+defp deps do
+  [{:brcpfcnpj, "~> 0.1.0"}]
+end
+```
 
-Foi inspirado na Gem * [brcpfcnpj](https://github.com/tapajos/brazilian-rails/tree/master/brcpfcnpj)
+> Para Elixir `< 1.2` utilize a versão `0.0.11`. [Veja detalhes](https://github.com/williamgueiros/Brcpfcnpj/issues/5).
 
-Recebem strings representando números de cpf/cnpj e verificam a validade destes números usando dois critérios:
+## Validação de CPF/CNPJ
 
-1. O formato da string, que deve seguir o padrão xx.xxx.xxx/xxxx-xx, onde 'x' pode ser qualquer dígito de 0 a 9 e os traços (-), barra (/) e pontos (.) *são opcionais*.
-2. O conteúdo numérico desta string, que é validado através do cálculo do 'módulo 11' dos dígitos que compõem a string.
+As funções recebem `Strings` representando o número do CPF ou CNPJ e verificam a validade destes números usando dois
+critérios:
 
-### Validando numeros de cpf
-```Elixir
+1. O formato da String, que deve seguir o padrão `XX.XXX.XXX/XXXX-XXX`, onde `X` pode ser qualquer dígito de `0` a `9`,
+sendo os traços `-`, barra `/` e pontos `.` opcionais.
+2. O conteúdo numérico desta String, validado através do cálculo do `módulo 11` dos dígitos que compõem a String.
+
+A função `Brcpfcnpj.cpf_valid?/1` verifica se uma String é um CPF válido:
+
+```elixir
 cpf = %Cpf{number: "11144477735"}
 Brcpfcnpj.cpf_valid?(cpf) # ==> true
 
@@ -26,8 +37,10 @@ cpf = %Cpf{number: "111.444.777-35"}
 Brcpfcnpj.cpf_valid?(cpf) # ==> true
 
 ````
-### Validando numero de cnpj
-```Elixir
+
+A função `Brcpfcnpj.cnpj_valid?/1` verifica se uma String é um CNPJ válido:
+
+```elixir
 cnpj = %Cnpj{number: "69103604000160"}
 Brcpfcnpj.cnpj_valid?(cnpj)# ==> true
 
@@ -35,14 +48,13 @@ cnpj = %Cnpj{number: "69.103.604/0001-60"}
 Brcpfcnpj.cnpj_valid?(cnpj)# ==> true
 ````
 
-##Formatando a String
-Existe a possibilidade de alem de validar, ter o retorno da String formatada.
-Caso a mesma seja valida terá o retorno da String em seu devido formato 69.103.604/0001-60.
-caso contratio tera de retorno nil.
+## Formatando a String
 
+As funções `Brcpfcnpj.cpf_format/1` e `Brcpfcnpj.cnpj_format` retornam a String válida no devido formato. Se a String
+não for válida, as funções retornam nil.
 
-```Elixir
-cpf = %Cpf{number: "11144477735"}      
+```elixir
+cpf = %Cpf{number: "11144477735"}
 Brcpfcnpj.cpf_format(cpf)  # ==>"111.444.777-35"
 
 cpf = %Cpf{number: "11144477734"}
@@ -50,7 +62,7 @@ Brcpfcnpj.cpf_format(cpf)  # ==> nil
 
 ````
 
-```Elixir
+```elixir
 cnpj = %Cnpj{number: "69103604000160"}
 Brcpfcnpj.cnpj_format(cnpj) # ==>"69.103.604/0001-60"
 
@@ -58,11 +70,12 @@ cnpj = %Cnpj{number: "69103604000161"}
 Brcpfcnpj.cnpj_format(cnpj) # ==> nil
 ````
 
-##Gerador de Cpf e Cnpj
+## Gerando números CPF e CNPJ
 
-Gerando o Cpf e Cnpj com formatação
+Use as funções `Brcpfcnpj.cpf_generate/1` e `Brcpfcnpj.cnpj_generate/1` para gerar CPFs e CNPJs válidos. O parâmetro
+das funções indica se os números devem ser formatados.
 
-```Elixir
+```elixir
 Brcpfcnpj.cpf_generate true
 "468.535.974-78"
 
@@ -70,9 +83,9 @@ Brcpfcnpj.cnpj_generate true
 "45.044.251/6215-69"
 ````
 
-Gerando o Cpf e Cnpj sem formatação
+Sem formatação:
 
-```Elixir
+```elixir
 Brcpfcnpj.cpf_generate
 "02239513403"
 
@@ -80,28 +93,37 @@ Brcpfcnpj.cnpj_generate
 "17463578863541"
 ````
 
-## Utilizando em conjunto com o Ecto
-O modulo ```Brcpfcnpj.Changeset``` contém algumas funções que podem
-ser utilizadas em conjunto com a API de changesets do Ecto.
+## Ecto
+
+O modulo `Brcpfcnpj.Changeset` contém algumas funções que podem ser utilizadas em conjunto com a API de Changesets
+do Ecto.
+
 ```elixir
 import Brcpfcnpj.Changeset
 
 def changeset(model, params \\ :empty) do
-    model
-    |> cast(params, @required_fields, @optional_fields)
-    |> validate_cnpj(:cnpj)
-    |> validate_cpf(:cpf)
+  model
+  |> cast(params, @required_fields, @optional_fields)
+  |> validate_cnpj(:cnpj)
+  |> validate_cpf(:cpf)
 end
 ```
 
-Por padrão esses validadores adicionam a mensagem "Invalid Cnpj/Cpf" a lista de erros.
-Essa mensagem pode ser configurada com o parâmetro "message".
+Por padrão esses validadores adicionam a mensagem "Invalid CNPJ/CPF" na lista de erros. Essa mensagem pode ser
+configurada com o parâmetro `message`:
+
 ```elixir
 validate_cnpj(:cnpj, message: "Cnpj Inválido")
 ```
 
-Em caso de duvida de uso recomendo está leitura [mais](https://github.com/williamgueiros/Brcpfcnpj/issues/3#issuecomment-191368591)
+Em caso de duvida [veja mais detalhes](https://github.com/williamgueiros/Brcpfcnpj/issues/3#issuecomment-191368591).
 
-#### Contribuição
-[Diogo Beda](https://github.com/diogobeda), [Tiago Henrique Engel](https://github.com/tiagoengel)
+## Contribuições
+
+* [Diogo Beda](https://github.com/diogobeda)
+* [Tiago Henrique Engel](https://github.com/tiagoengel)
+
+## Agradecimentos
+
+Inspirado na gem [brcpfcnpj](https://github.com/tapajos/brazilian-rails/tree/master/brcpfcnpj).
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,18 +21,17 @@ defmodule Brcpfcnpj.Mixfile do
   end
 
   defp description do
-      """
-      Coleção de funções para validação e formatação de CPF e CNPJ.
+    """
+    Colecao de funcoes para validacao e formatacao de CPF e CNPJ.
 
-      Validation and format for brazilian id documents (CPF/CNPJ).
-      """
-    end
-
-  defp package do
-     [files: ~w(lib test config mix.exs README*),
-   maintainers: ["William Gueiros"],
-   licenses: ["Unlicense"],
-   links: %{"GitHub" => "https://github.com/williamgueiros/Brcpfcnpj"}]
+    Validation and format for brazilian id documents (CPF/CNPJ).
+    """
   end
 
+  defp package do
+    [files: ~w(lib test config mix.exs README*),
+     maintainers: ["William Gueiros"],
+     licenses: ["Unlicense"],
+     links: %{"GitHub" => "https://github.com/williamgueiros/Brcpfcnpj"}]
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,22 +17,22 @@ defmodule Brcpfcnpj.Mixfile do
   defp deps do
     [{:earmark, "~> 0.2.1", only: :dev},
      {:ex_doc, "~> 0.11.4", only: :dev},
-	 {:inch_ex, "~> 0.5.1", only: :docs}]
+     {:inch_ex, "~> 0.5.1", only: :docs}]
   end
-  
+
   defp description do
       """
-      Valida Cpf/Cnpj e Formatar em String caso necessario
-	  
-	  Number format and Validate, to the documents brazilians (CPF/CNPJ)
+      Coleção de funções para validação e formatação de CPF e CNPJ.
+
+      Validation and format for brazilian id documents (CPF/CNPJ).
       """
     end
-	
+
   defp package do
      [files: ~w(lib test config mix.exs README*),
-	 maintainers: ["William Gueiros"],
-	 licenses: ["Unlicense"],
-	 links: %{"GitHub" => "https://github.com/williamgueiros/Brcpfcnpj"}]
-  end	
+   maintainers: ["William Gueiros"],
+   licenses: ["Unlicense"],
+   links: %{"GitHub" => "https://github.com/williamgueiros/Brcpfcnpj"}]
+  end
 
 end


### PR DESCRIPTION
Olá @williamgueiros. Dei uma organizada no README e no `mix.exs`. 

Notei que vários arquivos da lib estão com espaçamento simples e tab misturados. Seria legal seguir o [styleguide](https://github.com/niftyn8/elixir_style_guide) e usar somente o espaçamento simples com dois espaços para melhorar a legibilidade do código.

Obrigado pelo trampo na lib 👍 