### PR TITLE
Update ecto changeset

### DIFF
--- a/lib/changeset.ex
+++ b/lib/changeset.ex
@@ -4,6 +4,8 @@ defmodule Brcpfcnpj.Changeset do
   Ecto.
   """
 
+  import Ecto.Changeset, only: [validate_change: 3]
+
   @type t :: %{valid?: boolean(),
                changes: %{atom => term},
                errors: [error]}
@@ -26,10 +28,11 @@ defmodule Brcpfcnpj.Changeset do
   """
   @spec validate_cnpj(t, atom, Keyword.t) :: t
   def validate_cnpj(changeset, field, opts \\ []) when is_atom(field) do
-    validate changeset, field, fn value ->
-      cond do
-        Brcpfcnpj.cnpj_valid?(%Cnpj{number: value}) -> []
-        true -> [{field, message(opts, "Invalid Cnpj")}]
+    validate_change changeset, field, fn _, value ->
+      if Brcpfcnpj.cnpj_valid?(%Cnpj{number: value}) do
+        []
+      else
+        [{field, message(opts, "Invalid Cnpj")}]
       end
     end
   end
@@ -48,23 +51,12 @@ defmodule Brcpfcnpj.Changeset do
   """
   @spec validate_cpf(t, atom, Keyword.t) :: t
   def validate_cpf(changeset, field, opts \\ []) when is_atom(field) do
-    validate changeset, field, fn value ->
-      cond do
-        Brcpfcnpj.cpf_valid?(%Cpf{number: value}) -> []
-        true -> [{field, message(opts, "Invalid Cpf")}]
+    validate_change changeset, field, fn _, value ->
+      if Brcpfcnpj.cpf_valid?(%Cpf{number: value}) do
+        []
+      else
+        [{field, message(opts, "Invalid Cpf")}]
       end
-    end
-  end
-
-  defp validate(changeset, field, validator) do
-    %{changes: changes, errors: errors} = changeset
-
-    value = Map.get(changes, field)
-    new  = if is_nil(value), do: [], else: validator.(value)
-
-    case new do
-      []    -> changeset
-      [_|_] -> %{changeset | errors: new ++ errors, valid?: false}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Brcpfcnpj.Mixfile do
   defp deps do
     [{:earmark, "~> 0.2.1", only: :dev},
      {:ex_doc, "~> 0.11.4", only: :dev},
+     {:ecto, ">= 2.0.0"},
      {:inch_ex, "~> 0.5.1", only: :docs}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "inch_ex": {:hex, :inch_ex, "0.5.1"},
-  "poison": {:hex, :poison, "2.1.0"}}
+%{"decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.0.6", "9dcbf819c2a77f67a66b83739b7fcc00b71aaf6c100016db4f798930fa4cfd47", [], [{:db_connection, "~> 1.0", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "0.5.1", "c1c18966c935944cbb2d273796b36e44fab3c54fd59f906ff026a686205b4e14", [], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"}}

--- a/test/changeset_test.exs
+++ b/test/changeset_test.exs
@@ -14,7 +14,7 @@ defmodule ChangesetTest do
 		changeset = cast(%{cnpj: "1234"}) |> validate_cnpj(:cnpj)
     refute changeset.valid?
     %{errors: errors} = changeset
-    assert errors[:cnpj] == "Invalid Cnpj"
+    assert errors[:cnpj] == {"Invalid Cnpj", []}
 	end
 
 	test "changeset with valid cnpj" do
@@ -26,7 +26,7 @@ defmodule ChangesetTest do
 		changeset = cast(%{cpf: "1234"}) |> validate_cpf(:cpf)
     refute changeset.valid?
     %{errors: errors} = changeset
-    assert errors[:cpf] == "Invalid Cpf"
+    assert errors[:cpf] == {"Invalid Cpf", []}
 	end
 
 	test "changeset with valid cpf" do
@@ -34,14 +34,14 @@ defmodule ChangesetTest do
     assert changeset.valid?
 	end
 
-	test "custon error message" do
+	test "custom error message" do
 		changeset = cast(%{cnpj: "1234", cpf: "123"})
 			|> validate_cnpj(:cnpj, message: "Cnpj Inválido")
 			|> validate_cpf(:cpf, message: "Cpf Inválido")
 
 		%{errors: errors} = changeset
-		assert errors[:cnpj] == "Cnpj Inválido"
-		assert errors[:cpf] == "Cpf Inválido"
+		assert errors[:cnpj] == {"Cnpj Inválido", []}
+		assert errors[:cpf] == {"Cpf Inválido", []}
 	end
 
 end


### PR DESCRIPTION
This fixes #7 

I'm using `Ecto.Changeset.validate_change` instead of our version. This will make it forward compatible with future versions of Ecto (because, right now, we're using a documented API to create changeset errors), but this leaves two things to think about:

* Will we add Ecto as a dependency for this project? Or, it'll be only for development? (in this PR, I've made it a dependency for every env)
* Is there a better way to test for errors? Right now, we're testing Ecto's changeset format. Would this change in the future, we'll have a false negative on our tests