### PR TITLE
mix format all files

### DIFF
--- a/lib/brcpfcnpj.ex
+++ b/lib/brcpfcnpj.ex
@@ -1,106 +1,108 @@
 defmodule Brcpfcnpj do
-    @moduledoc ~S"""
-	Valida Cpf/Cnpj e Formatar em String caso necessario
-	1. O formato da string, que deve seguir o padrão xx.xxx.xxx/xxxx-xx, onde 'x' pode ser qualquer dígito de 0 a 9 e os traços (-), barra (/) e pontos (.) *são opcionais*.
-	2. O conteúdo numérico desta string, que é validado através do cálculo do 'módulo 11' dos dígitos que compõem a string.
+  @moduledoc ~S"""
+  Valida Cpf/Cnpj e Formatar em String caso necessario
+  1. O formato da string, que deve seguir o padrão xx.xxx.xxx/xxxx-xx,
+	onde 'x' pode ser qualquer dígito de 0 a 9 e os traços (-), barra (/)
+	e pontos (.) *são opcionais*.
+  2. O conteúdo numérico desta string, que é validado através do cálculo
+	do 'módulo 11' dos dígitos que compõem a string.
 
-    exemplos:
+  exemplos:
 
-        iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "111.444.777-35"})
-        true
-        iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"})
-        "111.444.777-35"
+      iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "111.444.777-35"})
+      true
+      iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"})
+      "111.444.777-35"
 
-	Com ou sem os caracteres especiais os mesmos serao validados
-    """
+  Com ou sem os caracteres especiais os mesmos serao validados
+  """
 
-    @doc ~S"""
-    Valida Cpf, realiza a chamda ao modulo Cpfcnpj com a estrutura correta.
-	forca o desenvolvedor passar os parametros de forma correta
+  @doc ~S"""
+  Valida Cpf, realiza a chamda ao modulo Cpfcnpj com a estrutura correta.
+  forca o desenvolvedor passar os parametros de forma correta
 
-    exemplos:
+  exemplos:
 
-        iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "11144477735"})
-        true
-        iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "111.444.777-35"})
-        true
+      iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "11144477735"})
+      true
+      iex>Brcpfcnpj.cpf_valid?(%Cpf{number: "111.444.777-35"})
+      true
 
-	Com ou sem os caracteres especiais os mesmos serao validados
-    """
+  Com ou sem os caracteres especiais os mesmos serao validados
+  """
 
-	def cpf_valid?(cpf=%Cpf{}) do
-		Cpfcnpj.valid?({cpf.tp_data,cpf.number})
-	end
+  def cpf_valid?(cpf = %Cpf{}) do
+    Cpfcnpj.valid?({cpf.tp_data, cpf.number})
+  end
 
-    @doc ~S"""
-    Valida Cnpj, realiza a chamda ao modulo Cpfcnpj com a estrutura correta.
-	forca o desenvolvedor passar os parametros de forma correta
+  @doc ~S"""
+  Valida Cnpj, realiza a chamda ao modulo Cpfcnpj com a estrutura correta.
+  forca o desenvolvedor passar os parametros de forma correta
 
-    Exemplos
+  Exemplos
 
-        iex>Brcpfcnpj.cnpj_valid?(%Cnpj{number: "69103604000160"})
-        true
-        iex>Brcpfcnpj.cnpj_valid?(%Cnpj{number: "69.103.604/0001-60"})
-        true
+      iex>Brcpfcnpj.cnpj_valid?(%Cnpj{number: "69103604000160"})
+      true
+      iex>Brcpfcnpj.cnpj_valid?(%Cnpj{number: "69.103.604/0001-60"})
+      true
 
-    """
+  """
 
-	def cnpj_valid?(cnpj=%Cnpj{}) do
-		Cpfcnpj.valid?({cnpj.tp_data,cnpj.number})
-	end
+  def cnpj_valid?(cnpj = %Cnpj{}) do
+    Cpfcnpj.valid?({cnpj.tp_data, cnpj.number})
+  end
 
-    @doc ~S"""
-    Valida o Cpf e retorna uma String do Cpf formatado
-	Caso seja invalido retorna nil
+  @doc ~S"""
+  Valida o Cpf e retorna uma String do Cpf formatado
+  Caso seja invalido retorna nil
 
-    Exemplos
+  Exemplos
 
-        iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"})
-        "111.444.777-35"
-        iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477734"})
-        nil
-    """
+      iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"})
+      "111.444.777-35"
+      iex>Brcpfcnpj.cpf_format(%Cpf{number: "11144477734"})
+      nil
+  """
 
-	def cpf_format(cpf=%Cpf{}) do
-		Cpfcnpj.format_number({cpf.tp_data,cpf.number})
-	end
+  def cpf_format(cpf = %Cpf{}) do
+    Cpfcnpj.format_number({cpf.tp_data, cpf.number})
+  end
 
-    @doc ~S"""
-    Valida o Cnpj e retorna uma String do Cnpj formatado
-	Caso seja invalido retorna nil
+  @doc ~S"""
+  Valida o Cnpj e retorna uma String do Cnpj formatado
+  Caso seja invalido retorna nil
 
-    Exemplos
+  Exemplos
 
-        iex>Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000160"})
-        "69.103.604/0001-60"
-        iex> Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000161"})
-        nil
-    """
+      iex>Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000160"})
+      "69.103.604/0001-60"
+      iex> Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000161"})
+      nil
+  """
 
-	def cnpj_format(cnpj=%Cnpj{}) do
-		Cpfcnpj.format_number({cnpj.tp_data,cnpj.number})
-	end
+  def cnpj_format(cnpj = %Cnpj{}) do
+    Cpfcnpj.format_number({cnpj.tp_data, cnpj.number})
+  end
 
+  @doc """
+  Responsavel por gerar um Cpf válido, formatado ou não
+  Caso seja passado o parametro true recebera o mesmo formatado
+  """
 
-	@doc """
-	Responsavel por gerar um Cpf válido, formatado ou não
-	Caso seja passado o parametro true recebeca o mesmo formatado
-	"""
+  def cpf_generate(format \\ false) do
+    tp_data = %Cpf{}.tp_data
+    cpf = Cpfcnpj.generate(tp_data)
+    if format, do: Cpfcnpj.format_number({tp_data, cpf}), else: cpf
+  end
 
-	def cpf_generate (format \\ false) do
-		tp_data = %Cpf{}.tp_data
-		cpf = Cpfcnpj.generate(tp_data)
-		if format, do: Cpfcnpj.format_number({ tp_data, cpf }), else: cpf
-	end
+  @doc """
+  Responsavel por gerar um Cnpj válido, formatado ou não
+  Caso seja passado o parametro true recebera o mesmo formatado
+  """
 
-	@doc """
-	Responsavel por gerar um Cnpj válido, formatado ou não
-	Caso seja passado o parametro true recebeca o mesmo formatado
-	"""
-
-	def cnpj_generate (format \\ false) do
-		tp_data = %Cnpj{}.tp_data
-		cnpj = Cpfcnpj.generate(tp_data)
-		if format, do: Cpfcnpj.format_number({ tp_data, cnpj }), else: cnpj
-	end
+  def cnpj_generate(format \\ false) do
+    tp_data = %Cnpj{}.tp_data
+    cnpj = Cpfcnpj.generate(tp_data)
+    if format, do: Cpfcnpj.format_number({tp_data, cnpj}), else: cnpj
+  end
 end

--- a/lib/changeset.ex
+++ b/lib/changeset.ex
@@ -4,13 +4,10 @@ defmodule Brcpfcnpj.Changeset do
   Ecto.
   """
 
-  @type t :: %{valid?: boolean(),
-               changes: %{atom => term},
-               errors: [error]}
+  @type t :: %{valid?: boolean(), changes: %{atom => term}, errors: [error]}
 
   @type error :: {atom, error_message}
-  @type error_message :: String.t | {String.t, Keyword.t}
-
+  @type error_message :: String.t() | {String.t(), Keyword.t()}
 
   @doc """
   Valida se essa mudação é um cnpj válido.
@@ -24,14 +21,14 @@ defmodule Brcpfcnpj.Changeset do
       validate_cnpj(changeset, :cnpj)
 
   """
-  @spec validate_cnpj(t, atom, Keyword.t) :: t
+  @spec validate_cnpj(t, atom, Keyword.t()) :: t
   def validate_cnpj(changeset, field, opts \\ []) when is_atom(field) do
-    validate changeset, field, fn value ->
+    validate(changeset, field, fn value ->
       cond do
         Brcpfcnpj.cnpj_valid?(%Cnpj{number: value}) -> []
         true -> [{field, message(opts, "Invalid Cnpj")}]
       end
-    end
+    end)
   end
 
   @doc """
@@ -46,29 +43,28 @@ defmodule Brcpfcnpj.Changeset do
       validate_cpf(changeset, :cpf)
 
   """
-  @spec validate_cpf(t, atom, Keyword.t) :: t
+  @spec validate_cpf(t, atom, Keyword.t()) :: t
   def validate_cpf(changeset, field, opts \\ []) when is_atom(field) do
-    validate changeset, field, fn value ->
+    validate(changeset, field, fn value ->
       cond do
         Brcpfcnpj.cpf_valid?(%Cpf{number: value}) -> []
         true -> [{field, message(opts, "Invalid Cpf")}]
       end
-    end
+    end)
   end
 
   defp validate(changeset, field, validator) do
     %{changes: changes, errors: errors} = changeset
 
     value = Map.get(changes, field)
-    new  = if is_nil(value), do: [], else: validator.(value)
+    new = if is_nil(value), do: [], else: validator.(value)
 
     case new do
-      []    -> changeset
-      [_|_] -> %{changeset | errors: new ++ errors, valid?: false}
+      [] -> changeset
+      [_ | _] -> %{changeset | errors: new ++ errors, valid?: false}
     end
   end
 
   defp message([message: msg], _), do: msg
   defp message(_, default), do: default
-
 end

--- a/lib/cpf.ex
+++ b/lib/cpf.ex
@@ -1,8 +1,8 @@
 defmodule Cpf do
-	@moduledoc """
-	  Associa uma strutura de cpf, para validacoes 
-	  Os campos sao:
-	    * 'number' - Numero do cpf ex: 11144477735,111.444.777-35 ou 111.444.77735
-	  """
-	defstruct number: nil, tp_data: :cpf
+  @moduledoc """
+  Associa uma strutura de cpf, para validacoes 
+  Os campos sao:
+    * 'number' - Numero do cpf ex: 11144477735,111.444.777-35 ou 111.444.77735
+  """
+  defstruct number: nil, tp_data: :cpf
 end

--- a/lib/cpfcnpj.ex
+++ b/lib/cpfcnpj.ex
@@ -1,135 +1,143 @@
 defmodule Cpfcnpj do
-	@moduledoc ~S"""
-	Modulo responsavel pro realizar todos os calculos de validacao
+  @moduledoc ~S"""
+  Modulo responsavel pro realizar todos os calculos de validacao
 
-	exemplos:
+  exemplos:
 
-        iex>Cpfcnpj.valid?({:cnpj,"69.103.604/0001-60"})
-        true
-        iex>Cpfcnpj.valid?({:cpf,"111.444.777-35"})
-        true
+         iex>Cpfcnpj.valid?({:cnpj,"69.103.604/0001-60"})
+         true
+         iex>Cpfcnpj.valid?({:cpf,"111.444.777-35"})
+         true
 
-	Com ou sem os caracteres especiais os mesmos serao validados
-	"""
-	@division 11
+  Com ou sem os caracteres especiais os mesmos serao validados
+  """
+  @division 11
 
-	@cpf_length 11
-    @cpf_algs_1 [10, 9, 8, 7, 6, 5, 4, 3, 2,0,0]
-    @cpf_algs_2 [11, 10, 9, 8, 7, 6, 5, 4, 3, 2,0]
-	@cpf_regex  ~r/(\d{3})?(\d{3})?(\d{3})?(\d{2})/
+  @cpf_length 11
+  @cpf_algs_1 [10, 9, 8, 7, 6, 5, 4, 3, 2, 0, 0]
+  @cpf_algs_2 [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 0]
+  @cpf_regex ~r/(\d{3})?(\d{3})?(\d{3})?(\d{2})/
 
-	@cnpj_length 14
-    @cnpj_algs_1 [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2,0,0]
-    @cnpj_algs_2 [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2,0]
-	@cnpj_regex ~r/(\d{2})?(\d{3})?(\d{3})?(\d{4})?(\d{2})/
+  @cnpj_length 14
+  @cnpj_algs_1 [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 0, 0]
+  @cnpj_algs_2 [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 0]
+  @cnpj_regex ~r/(\d{2})?(\d{3})?(\d{3})?(\d{4})?(\d{2})/
 
-    @doc ~S"""
-    Valida cpf/cnpj caracteres especias nao sao levados em consideracao
+  @doc ~S"""
+  Valida cpf/cnpj caracteres especias nao sao levados em consideracao
 
-    ## Exemplos
+  ## Exemplos
 
-        iex>Cpfcnpj.valid?({:cnpj,"69.103.604/0001-60"})
-        true
+      iex>Cpfcnpj.valid?({:cnpj,"69.103.604/0001-60"})
+      true
 
-    """
-	def valid?(number_in) do
-		if check_number(number_in) != :error, do: type_checker(number_in), else: false
-	end
+  """
+  def valid?(number_in) do
+    if check_number(number_in) != :error, do: type_checker(number_in), else: false
+  end
 
-	defp check_number({_, nil}) do
-		:error
-	end
+  defp check_number({_, nil}) do
+    :error
+  end
 
   defp check_number(tp_cpfcnpj) do
-		cpfcnpj=String.replace(elem(tp_cpfcnpj,1), ~r/[\.\/-]/, "")
+    cpfcnpj = String.replace(elem(tp_cpfcnpj, 1), ~r/[\.\/-]/, "")
 
-		all_equal = String.replace(cpfcnpj, String.at(cpfcnpj, 0), "")
-		|>String.length
+    all_equal =
+      String.replace(cpfcnpj, String.at(cpfcnpj, 0), "")
+      |> String.length()
 
-		case tp_cpfcnpj do
-			{:cpf,_} ->
-				if String.length(cpfcnpj) != @cpf_length or all_equal == 0 do
-					:error
-				end
-			{:cnpj,_} ->
-				if String.length(cpfcnpj) != @cnpj_length or all_equal == 0 do
-					:error
-				end
-		end
+    case tp_cpfcnpj do
+      {:cpf, _} ->
+        if String.length(cpfcnpj) != @cpf_length or all_equal == 0 do
+          :error
+        end
+
+      {:cnpj, _} ->
+        if String.length(cpfcnpj) != @cnpj_length or all_equal == 0 do
+          :error
+        end
+    end
   end
 
-	defp type_checker(tp_cpfcnpj) do
-		cpfcnpj=String.replace(elem(tp_cpfcnpj,1), ~r/[^0-9]/, "")
-		first_char_valid = character_valid(cpfcnpj,{elem(tp_cpfcnpj,0),:first})
-		second_char_valid = character_valid(cpfcnpj,{elem(tp_cpfcnpj,0),:second})
-		verif = first_char_valid <> second_char_valid
-		verif == String.slice(cpfcnpj,-2,2)
-	end
+  defp type_checker(tp_cpfcnpj) do
+    cpfcnpj = String.replace(elem(tp_cpfcnpj, 1), ~r/[^0-9]/, "")
+    first_char_valid = character_valid(cpfcnpj, {elem(tp_cpfcnpj, 0), :first})
+    second_char_valid = character_valid(cpfcnpj, {elem(tp_cpfcnpj, 0), :second})
+    verif = first_char_valid <> second_char_valid
+    verif == String.slice(cpfcnpj, -2, 2)
+  end
 
   defp mult_sum(algs, cpfcnpj) do
-		mult = cpfcnpj
-		|> String.codepoints
-		|> Enum.with_index
-		|> Enum.map(fn {k, v} -> String.to_integer(k) * Enum.at(algs,v) end)
-		Enum.reduce(mult, 0, &+/2)
+    mult =
+      cpfcnpj
+      |> String.codepoints()
+      |> Enum.with_index()
+      |> Enum.map(fn {k, v} -> String.to_integer(k) * Enum.at(algs, v) end)
+
+    Enum.reduce(mult, 0, &+/2)
   end
 
-	defp character_calc(remainder) do
-		if remainder < 2, do: 0, else: @division - remainder
+  defp character_calc(remainder) do
+    if remainder < 2, do: 0, else: @division - remainder
   end
 
-  defp character_valid(cpfcnpj,valid_type) do
-		array = case valid_type do
-			{:cpf,:first} -> @cpf_algs_1
-			{:cnpj,:first} -> @cnpj_algs_1
-			{:cpf,:second} -> @cpf_algs_2
-			{:cnpj,:second} -> @cnpj_algs_2
-		end
+  defp character_valid(cpfcnpj, valid_type) do
+    array =
+      case valid_type do
+        {:cpf, :first} -> @cpf_algs_1
+        {:cnpj, :first} -> @cnpj_algs_1
+        {:cpf, :second} -> @cpf_algs_2
+        {:cnpj, :second} -> @cnpj_algs_2
+      end
 
-		mult_sum(array, cpfcnpj)
-		|> rem(@division)
-		|> character_calc
-		|> Integer.to_string
+    mult_sum(array, cpfcnpj)
+    |> rem(@division)
+    |> character_calc
+    |> Integer.to_string()
   end
 
-    @doc ~S"""
-    Valida o Cpf/Cnpj e retorna uma String com o mesmo formatado
-	Caso seja invalido retorna nil
+  @doc ~S"""
+  Valida o Cpf/Cnpj e retorna uma String com o mesmo formatado
+  Caso seja invalido retorna nil
 
-    ## Exemplos
-        iex> Cpfcnpj.format_number({:cnpj,"69.103.604/0001-60"})
-        "69.103.604/0001-60"
+  ## Exemplos
+      iex> Cpfcnpj.format_number({:cnpj,"69.103.604/0001-60"})
+      "69.103.604/0001-60"
 
-    """
-	def format_number(number_in) do
-		if valid?(number_in) do
-			tp_cpfcnpj={elem(number_in,0),String.replace(elem(number_in,1), ~r/[^0-9]/, "")}
-			case tp_cpfcnpj do
-				{:cpf,cpf} ->
-					Regex.replace(@cpf_regex, cpf,"\\1.\\2.\\3-\\4")
-				{:cnpj,cnpj} ->
-					Regex.replace(@cnpj_regex, cnpj,"\\1.\\2.\\3/\\4-\\5")
-			end
-		else
-			nil
-		end
-	end
+  """
+  def format_number(number_in) do
+    if valid?(number_in) do
+      tp_cpfcnpj = {elem(number_in, 0), String.replace(elem(number_in, 1), ~r/[^0-9]/, "")}
 
-    @doc ~S"""
-    Gerador de cpf/cnpj concatenado com o digito verificador
-    """
-	def generate(tp_cpfcnpj) do
-		numbers = random_numbers(tp_cpfcnpj)
-		first_valid_char = character_valid(numbers, { tp_cpfcnpj, :first })
-		second_valid_char = character_valid(numbers <> first_valid_char, { tp_cpfcnpj, :second })
+      case tp_cpfcnpj do
+        {:cpf, cpf} ->
+          Regex.replace(@cpf_regex, cpf, "\\1.\\2.\\3-\\4")
 
-		numbers <> first_valid_char <> second_valid_char
-	end
+        {:cnpj, cnpj} ->
+          Regex.replace(@cnpj_regex, cnpj, "\\1.\\2.\\3/\\4-\\5")
+      end
+    else
+      nil
+    end
+  end
 
-	defp random_numbers (tp_cpfcnpj) do
-		numbersList = Enum.to_list(0..9)
-		Stream.repeatedly(fn -> round numbersList |> Enum.random end)
-		|> Enum.take((if tp_cpfcnpj == :cpf, do: @cpf_length, else: @cnpj_length) - 2)
-		|> Enum.reduce("", &(Integer.to_string(&1)<>&2));
-	end
+  @doc ~S"""
+  Gerador de cpf/cnpj concatenado com o digito verificador
+  """
+  def generate(tp_cpfcnpj) do
+    numbers = random_numbers(tp_cpfcnpj)
+    first_valid_char = character_valid(numbers, {tp_cpfcnpj, :first})
+    second_valid_char = character_valid(numbers <> first_valid_char, {tp_cpfcnpj, :second})
+
+    numbers <> first_valid_char <> second_valid_char
+  end
+
+  defp random_numbers(tp_cpfcnpj) do
+    numbersList = Enum.to_list(0..9)
+
+    Stream.repeatedly(fn -> round(numbersList |> Enum.random()) end)
+    |> Enum.take(if(tp_cpfcnpj == :cpf, do: @cpf_length, else: @cnpj_length) - 2)
+    |> Enum.reduce("", &(Integer.to_string(&1) <> &2))
+  end
 end

--- a/lib/cpnj.ex
+++ b/lib/cpnj.ex
@@ -1,8 +1,8 @@
 defmodule Cnpj do
-	@moduledoc """
-	  Associa uma strutura de Cnpj, para validacoes 
-	  Os campos sao:
-	    * 'number' - Numero do Cnpj ex: 69103604000160,69.103.604/0001-60 ou 69.103.604000160
-	  """
-	defstruct number: nil, tp_data: :cnpj
+  @moduledoc """
+  Associa uma strutura de Cnpj, para validacoes 
+  Os campos sao:
+    * 'number' - Numero do Cnpj ex: 69103604000160,69.103.604/0001-60 ou 69.103.604000160
+  """
+  defstruct number: nil, tp_data: :cnpj
 end

--- a/test/brcpfcnpj_test.exs
+++ b/test/brcpfcnpj_test.exs
@@ -1,52 +1,53 @@
 defmodule BrcpfcnpjTest do
-	use ExUnit.Case
-	doctest Brcpfcnpj
-	doctest Cpfcnpj
+  use ExUnit.Case
+  doctest Brcpfcnpj
+  doctest Cpfcnpj
 
-	test "should return the formated cpf" do
-		assert Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"}) =="111.444.777-35"
-	end
-	test "should return the formated to wrong cpf" do
-		assert Brcpfcnpj.cpf_format(%Cpf{number: "11144477731"}) ==nil
-	end
+  test "should return the formated cpf" do
+    assert Brcpfcnpj.cpf_format(%Cpf{number: "11144477735"}) == "111.444.777-35"
+  end
 
-	test "should return the formated cnpj" do
-    assert Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000160"}) =="69.103.604/0001-60"
-	end
+  test "should return the formated to wrong cpf" do
+    assert Brcpfcnpj.cpf_format(%Cpf{number: "11144477731"}) == nil
+  end
 
-	test "should return the formated to wrong cnpj" do
-		assert Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000161"}) ==nil
-	end
+  test "should return the formated cnpj" do
+    assert Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000160"}) == "69.103.604/0001-60"
+  end
 
-	test "should generate a valid cpf" do
-		assert Brcpfcnpj.cpf_valid?(%Cpf{ number: Brcpfcnpj.cpf_generate })
-	end
+  test "should return the formated to wrong cnpj" do
+    assert Brcpfcnpj.cnpj_format(%Cnpj{number: "69103604000161"}) == nil
+  end
 
-	test "should generate a valid cnpj" do
-		assert Brcpfcnpj.cnpj_valid?(%Cnpj{ number: Brcpfcnpj.cnpj_generate })
-	end
+  test "should generate a valid cpf" do
+    assert Brcpfcnpj.cpf_valid?(%Cpf{number: Brcpfcnpj.cpf_generate()})
+  end
 
-	test "should generate a formatted cpf" do
-		cpf = Brcpfcnpj.cpf_generate true
-		assert Regex.match?(~r/(\d{3})[.]?(\d{3})[.]?(\d{3})[-]?(\d{2})/, cpf)
-		assert %Cpf{number: cpf} |> Brcpfcnpj.cpf_valid?
-	end
+  test "should generate a valid cnpj" do
+    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: Brcpfcnpj.cnpj_generate()})
+  end
 
-	test "should generate a formatted cnpj" do
-		cnpj = Brcpfcnpj.cnpj_generate true
-		assert Regex.match?(~r/(\d{2})[.]?(\d{3})[.]?(\d{3})[\/]?(\d{4})[-]?(\d{2})/, cnpj)
-		assert %Cnpj{number: cnpj} |> Brcpfcnpj.cnpj_valid?
-	end
-	
-	test "should generate a cpf" do
-		cpf = Brcpfcnpj.cpf_generate
-		assert cpf |> String.length == 11
-		assert %Cpf{number: cpf} |> Brcpfcnpj.cpf_valid?
-	end
+  test "should generate a formatted cpf" do
+    cpf = Brcpfcnpj.cpf_generate(true)
+    assert Regex.match?(~r/(\d{3})[.]?(\d{3})[.]?(\d{3})[-]?(\d{2})/, cpf)
+    assert %Cpf{number: cpf} |> Brcpfcnpj.cpf_valid?()
+  end
 
-	test "should generate a cnpj" do
-		cnpj = Brcpfcnpj.cnpj_generate
-		assert cnpj |> String.length == 14
-		assert %Cnpj{number: cnpj} |> Brcpfcnpj.cnpj_valid?
-	end
+  test "should generate a formatted cnpj" do
+    cnpj = Brcpfcnpj.cnpj_generate(true)
+    assert Regex.match?(~r/(\d{2})[.]?(\d{3})[.]?(\d{3})[\/]?(\d{4})[-]?(\d{2})/, cnpj)
+    assert %Cnpj{number: cnpj} |> Brcpfcnpj.cnpj_valid?()
+  end
+
+  test "should generate a cpf" do
+    cpf = Brcpfcnpj.cpf_generate()
+    assert cpf |> String.length() == 11
+    assert %Cpf{number: cpf} |> Brcpfcnpj.cpf_valid?()
+  end
+
+  test "should generate a cnpj" do
+    cnpj = Brcpfcnpj.cnpj_generate()
+    assert cnpj |> String.length() == 14
+    assert %Cnpj{number: cnpj} |> Brcpfcnpj.cnpj_valid?()
+  end
 end

--- a/test/changeset_test.exs
+++ b/test/changeset_test.exs
@@ -1,5 +1,5 @@
 defmodule ChangesetTest do
-	use ExUnit.Case
+  use ExUnit.Case
   import Brcpfcnpj.Changeset
 
   defp cast(changes) do
@@ -10,38 +10,38 @@ defmodule ChangesetTest do
     }
   end
 
-	test "changeset with invalid cnpj" do
-		changeset = cast(%{cnpj: "1234"}) |> validate_cnpj(:cnpj)
+  test "changeset with invalid cnpj" do
+    changeset = cast(%{cnpj: "1234"}) |> validate_cnpj(:cnpj)
     refute changeset.valid?
     %{errors: errors} = changeset
     assert errors[:cnpj] == "Invalid Cnpj"
-	end
+  end
 
-	test "changeset with valid cnpj" do
-		changeset = cast(%{cnpj: Brcpfcnpj.cnpj_generate}) |> validate_cnpj(:cnpj)
+  test "changeset with valid cnpj" do
+    changeset = cast(%{cnpj: Brcpfcnpj.cnpj_generate()}) |> validate_cnpj(:cnpj)
     assert changeset.valid?
-	end
+  end
 
-	test "changeset with invalid cpf" do
-		changeset = cast(%{cpf: "1234"}) |> validate_cpf(:cpf)
+  test "changeset with invalid cpf" do
+    changeset = cast(%{cpf: "1234"}) |> validate_cpf(:cpf)
     refute changeset.valid?
     %{errors: errors} = changeset
     assert errors[:cpf] == "Invalid Cpf"
-	end
+  end
 
-	test "changeset with valid cpf" do
-		changeset = cast(%{cpf: Brcpfcnpj.cpf_generate}) |> validate_cpf(:cpf)
+  test "changeset with valid cpf" do
+    changeset = cast(%{cpf: Brcpfcnpj.cpf_generate()}) |> validate_cpf(:cpf)
     assert changeset.valid?
-	end
+  end
 
-	test "custon error message" do
-		changeset = cast(%{cnpj: "1234", cpf: "123"})
-			|> validate_cnpj(:cnpj, message: "Cnpj Inválido")
-			|> validate_cpf(:cpf, message: "Cpf Inválido")
+  test "custon error message" do
+    changeset =
+      cast(%{cnpj: "1234", cpf: "123"})
+      |> validate_cnpj(:cnpj, message: "Cnpj Inválido")
+      |> validate_cpf(:cpf, message: "Cpf Inválido")
 
-		%{errors: errors} = changeset
-		assert errors[:cnpj] == "Cnpj Inválido"
-		assert errors[:cpf] == "Cpf Inválido"
-	end
-
+    %{errors: errors} = changeset
+    assert errors[:cnpj] == "Cnpj Inválido"
+    assert errors[:cpf] == "Cpf Inválido"
+  end
 end

--- a/test/cnpj_test.exs
+++ b/test/cnpj_test.exs
@@ -1,31 +1,32 @@
 defmodule CnpjTest do
-	use ExUnit.Case
-	
-	test "should be invalid with invalid number" do
-		cnpjs = ~w{69103604020160 00000000000000 69.103.604/0001-61 01618211000264 11111111111111}
-		Enum.each(cnpjs, fn(cnpj) ->
-			 assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) ==false
-		end
-		)
-	end
-	  
-	test "should be invalid with a number longer than 14 chars, even if the first 14 represent a valid number" do
-		cnpjs = ~w{691036040001-601 69103604000160a 69103604000160ABC 6910360400016000}
-		Enum.each(cnpjs, fn(cnpj) ->
-			 assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) ==false
-		end
-		)
-	end
-	
-	test "should be valid with correct number" do
-		cnpjs = ~w{69103604000160 69.103.604/0001-60 01518211/000264 01.5182110002-64 00.000.000/1447-89}
-		Enum.each(cnpjs, fn(cnpj) ->
-			 assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) ==true
-		end
-		)
-	end
+  use ExUnit.Case
 
-	test "should be invalid with nil input" do
-		assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: nil}) == false
-	end
+  test "should be invalid with invalid number" do
+    cnpjs = ~w{69103604020160 00000000000000 69.103.604/0001-61 01618211000264 11111111111111}
+
+    Enum.each(cnpjs, fn cnpj ->
+      assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) == false
+    end)
+  end
+
+  test "should be invalid with a number longer than 14 chars, even if the first 14 represent a valid number" do
+    cnpjs = ~w{691036040001-601 69103604000160a 69103604000160ABC 6910360400016000}
+
+    Enum.each(cnpjs, fn cnpj ->
+      assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) == false
+    end)
+  end
+
+  test "should be valid with correct number" do
+    cnpjs =
+      ~w{69103604000160 69.103.604/0001-60 01518211/000264 01.5182110002-64 00.000.000/1447-89}
+
+    Enum.each(cnpjs, fn cnpj ->
+      assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: cnpj}) == true
+    end)
+  end
+
+  test "should be invalid with nil input" do
+    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: nil}) == false
+  end
 end

--- a/test/cpf_test.exs
+++ b/test/cpf_test.exs
@@ -1,40 +1,39 @@
 defmodule CpfTest do
-	use ExUnit.Case
-	
-    test "should be invalid with malformed number" do
-    	cpfs = ~w{345.65.67.3 567.765-87698 345456-654-01 123456}
-		Enum.each(cpfs, fn(cpf) ->
-		 	assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) ==false
-		end
-		)
-	
-    end
+  use ExUnit.Case
 
-    test "should be invalid with invalid number" do
-    	cpfs = ~w{23342345699 34.543.567-98 456.676456-87 333333333-33 00000000000 000.000.000-00}
-		Enum.each(cpfs, fn(cpf) ->
-		 	assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) ==false
-		end
-		)
-    end
+  test "should be invalid with malformed number" do
+    cpfs = ~w{345.65.67.3 567.765-87698 345456-654-01 123456}
 
-    test "should be valid with correct number" do
-    	cpfs = ~w{111.444.777-35 11144477735 111.444777-35 111444.777-35 111.444.77735}
-		Enum.each(cpfs, fn(cpf) ->
-		 	assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) ==true
-		end
-		)
-    end
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) == false
+    end)
+  end
 
-    test "should be invalid with a number longer than 11 chars, even if the first 11 char represent a valid cpf number" do
-    	cpfs = ~w{111.444.777-3500 11144477735AB}
-		Enum.each(cpfs, fn(cpf) ->
-		 	assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) ==false
-		end
-		)
-		end
-		
-		test "should be invalid with nil input" do
-		 	assert Brcpfcnpj.cpf_valid?(%Cpf{number: nil}) == false
-    end
+  test "should be invalid with invalid number" do
+    cpfs = ~w{23342345699 34.543.567-98 456.676456-87 333333333-33 00000000000 000.000.000-00}
+
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) == false
+    end)
+  end
+
+  test "should be valid with correct number" do
+    cpfs = ~w{111.444.777-35 11144477735 111.444777-35 111444.777-35 111.444.77735}
+
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) == true
+    end)
+  end
+
+  test "should be invalid with a number longer than 11 chars, even if the first 11 char represent a valid cpf number" do
+    cpfs = ~w{111.444.777-3500 11144477735AB}
+
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(%Cpf{number: cpf}) == false
+    end)
+  end
+
+  test "should be invalid with nil input" do
+    assert Brcpfcnpj.cpf_valid?(%Cpf{number: nil}) == false
+  end
 end


### PR DESCRIPTION
current formatting is causing warnings on most recent versions of elixir when compiling

```
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   /tmp/build_f1b5dd8eaf31f2aec795dbd25f073c48/deps/brcpfcnpj/mix.exs:27
remote:
remote: warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
remote:   /tmp/build_f1b5dd8eaf31f2aec795dbd25f073c48/deps/brcpfcnpj/mix.exs:8
remote:
remote: warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
remote:   /tmp/build_f1b5dd8eaf31f2aec795dbd25f073c48/deps/brcpfcnpj/mix.exs:9
remote:
remote: warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
remote:   /tmp/build_f1b5dd8eaf31f2aec795dbd25f073c48/deps/brcpfcnpj/mix.exs:10
remote:
remote: ==> brcpfcnpj
remote: Compiling 5 files (.ex)
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/brcpfcnpj.ex:14
remote:
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/brcpfcnpj.ex:28
remote:
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/brcpfcnpj.ex:37
remote:
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/brcpfcnpj.ex:54
remote:
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/brcpfcnpj.ex:70
remote:
remote: warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:
remote:
remote:     def text do
remote:       """
remote:     contents
remote:       """
remote:     end
remote:
remote: Instead make sure the contents are indented as much as the heredoc closing:
remote:
remote:     def text do
remote:       """
remote:       contents
remote:       """
remote:     end
remote:
remote: The current heredoc line is indented too little
remote:   lib/cpfcnpj.ex:93
remote:
remote: Generated brcpfcnpj app
```