### PR TITLE
Validar changeset por uma lista de campos

### DIFF
--- a/lib/changeset.ex
+++ b/lib/changeset.ex
@@ -4,15 +4,15 @@ defmodule Brcpfcnpj.Changeset do
   """
 
   @type t :: %{
-    changes: %{required(atom()) => term()},
-    errors: [{atom(), error()}],
-    valid?: boolean()
-  }
+          changes: %{required(atom()) => term()},
+          errors: [{atom(), error()}],
+          valid?: boolean()
+        }
   @type error :: {atom, error_message}
   @type error_message :: String.t() | {String.t(), Keyword.t()}
 
   @doc """
-  Valida se essa mudação é um cnpj válido.
+  Valida se essa mudança é um cnpj válido. Aceita um ou mais fields
 
   ## Options
 
@@ -22,9 +22,13 @@ defmodule Brcpfcnpj.Changeset do
 
       validate_cnpj(changeset, :cnpj)
 
+      validate_cnpj(changeset, [:cnpj, :other_cnpj])
+
   """
-  @spec validate_cnpj(t, atom, Keyword.t()) :: t
-  def validate_cnpj(changeset, field, opts \\ []) when is_atom(field) do
+  @spec validate_cnpj(t, atom | list, Keyword.t()) :: t
+  def validate_cnpj(changeset, field), do: validate_cnpj(changeset, field, [])
+
+  def validate_cnpj(changeset, field, opts) when is_atom(field) do
     validate(changeset, field, fn value ->
       cond do
         Brcpfcnpj.cnpj_valid?(%Cnpj{number: value}) -> []
@@ -33,8 +37,14 @@ defmodule Brcpfcnpj.Changeset do
     end)
   end
 
+  def validate_cnpj(changeset, fields, opts) when is_list(fields) do
+    Enum.reduce(fields, changeset, fn field, acc_changeset ->
+      validate_cnpj(acc_changeset, field, opts)
+    end)
+  end
+
   @doc """
-  Valida se essa mudação é um cpf válido.
+  Valida se essa mudança é um cpf válido. Aceita um ou mais fields
 
   ## Options
 
@@ -44,14 +54,24 @@ defmodule Brcpfcnpj.Changeset do
 
       validate_cpf(changeset, :cpf)
 
+      validate_cpf(changeset, [:cpf, :cnpj])
+
   """
-  @spec validate_cpf(t, atom, Keyword.t()) :: t
-  def validate_cpf(changeset, field, opts \\ []) when is_atom(field) do
+  @spec validate_cpf(t, atom | list, Keyword.t()) :: t
+  def validate_cpf(changeset, field), do: validate_cpf(changeset, field, [])
+
+  def validate_cpf(changeset, field, opts) when is_atom(field) do
     validate(changeset, field, fn value ->
       cond do
         Brcpfcnpj.cpf_valid?(%Cpf{number: value}) -> []
         true -> [{field, message(opts, {"Invalid Cpf", validation: :cpf})}]
       end
+    end)
+  end
+
+  def validate_cpf(changeset, fields, opts) when is_list(fields) do
+    Enum.reduce(fields, changeset, fn field, acc_changeset ->
+      validate_cpf(acc_changeset, field, opts)
     end)
   end
 

--- a/test/changeset_test.exs
+++ b/test/changeset_test.exs
@@ -34,7 +34,7 @@ defmodule ChangesetTest do
     assert changeset.valid?
   end
 
-  test "custon error message (string only)" do
+  test "custom error message (string only)" do
     changeset =
       cast(%{cnpj: "1234", cpf: "123"})
       |> validate_cnpj(:cnpj, message: "Cnpj Inválido")
@@ -45,7 +45,7 @@ defmodule ChangesetTest do
     assert errors[:cpf] == {"Cpf Inválido", []}
   end
 
-  test "custon error message (addicional info)" do
+  test "custom error message (addicional info)" do
     changeset =
       cast(%{cnpj: "1234", cpf: "123"})
       |> validate_cnpj(:cnpj, message: {"Cnpj Inválido", additional: "info"})
@@ -54,5 +54,43 @@ defmodule ChangesetTest do
     %{errors: errors} = changeset
     assert errors[:cnpj] == {"Cnpj Inválido", [additional: "info"]}
     assert errors[:cpf] == {"Cpf Inválido", [additional: "info"]}
+  end
+
+  test "changeset with list of invalid cnpj fields" do
+    changeset =
+      cast(%{my_cnpj: "12345", other_cnpj: "846864"})
+      |> validate_cnpj([:my_cnpj, :other_cnpj])
+
+    refute changeset.valid?
+    %{errors: errors} = changeset
+    assert errors[:my_cnpj] == {"Invalid Cnpj", validation: :cnpj}
+    assert errors[:other_cnpj] == {"Invalid Cnpj", validation: :cnpj}
+  end
+
+  test "changeset with a list of valid cnpj fields" do
+    changeset =
+      cast(%{my_cnpj: Brcpfcnpj.cnpj_generate(), other_cnpj: Brcpfcnpj.cnpj_generate()})
+      |> validate_cnpj([:my_cnpj, :other_cnpj])
+
+    assert changeset.valid?
+  end
+
+  test "changeset with list of invalid cpf fields" do
+    changeset =
+      cast(%{my_cpf: "12345", other_cpf: "846864"})
+      |> validate_cpf([:my_cpf, :other_cpf])
+
+    refute changeset.valid?
+    %{errors: errors} = changeset
+    assert errors[:my_cpf] == {"Invalid Cpf", validation: :cpf}
+    assert errors[:other_cpf] == {"Invalid Cpf", validation: :cpf}
+  end
+
+  test "changeset with a list of valid cpf fields" do
+    changeset =
+      cast(%{my_cpf: Brcpfcnpj.cpf_generate(), other_cpf: Brcpfcnpj.cpf_generate()})
+      |> validate_cpf([:my_cpf, :other_cpf])
+
+    assert changeset.valid?
   end
 end


### PR DESCRIPTION
Esse pr adiciona  a capacidade de validar cpfs ou cnpjs passando uma lista de campos, assim como é feito nas validações que vem com o ecto 

Sugestão de @mvibraim

Ex: https://hexdocs.pm/ecto/Ecto.Changeset.html#validate_required/3