### PR TITLE
Remove validação de numeros básicos

### DIFF
--- a/lib/cpfcnpj.ex
+++ b/lib/cpfcnpj.ex
@@ -86,21 +86,7 @@ defmodule Cpfcnpj do
 
     basic = String.slice(cnpj, 0..7)
 
-    not_allowed_basics = basic in ~w<
-      11111111
-      22222222
-      33333333
-      44444444
-      55555555
-      66666666
-      77777777
-      88888888
-      99999999 >
-
     cond do
-      not_allowed_basics ->
-        false
-
       order == "0000" ->
         false
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Brcpfcnpj.Mixfile do
   def project do
     [
       app: :brcpfcnpj,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.7",
       description: description(),
       package: package(),

--- a/test/cnpj_test.exs
+++ b/test/cnpj_test.exs
@@ -35,16 +35,4 @@ defmodule CnpjTest do
     assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "00000898246954"}) == false
     assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "00000136747140"}) == false
   end
-
-  test "should be invalid for basic orders" do
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "11111111030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "22222222030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "33333333030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "44444444030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "55555555030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "66666666030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "77777777030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "88888888030180"}) == false
-    assert Brcpfcnpj.cnpj_valid?(%Cnpj{number: "99999999030180"}) == false
-  end
 end


### PR DESCRIPTION
Parece que essa validação não existe realmente. Já encontrei 2 cnpjs que não passam por essa validação mas existem.