### PR TITLE
fix: issue 46

### DIFF
--- a/lib/cpfcnpj.ex
+++ b/lib/cpfcnpj.ex
@@ -23,6 +23,8 @@ defmodule Cpfcnpj do
   @cnpj_algs_2 [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 0]
   @cnpj_regex ~r/([0-9A-Z]{2})[.]?([0-9A-Z]{3})[.]?([0-9A-Z]{3})[\/]?([0-9A-Z]{4})[-]?([0-9A-Z]{2})/
 
+  @digit_regex ~r/^\d+$/
+
   @cnpj_characters 48..57
                    |> Enum.to_list()
                    |> Kernel.++(Enum.to_list(65..90))
@@ -134,7 +136,8 @@ defmodule Cpfcnpj do
       order == "0000" ->
         false
 
-      cnpj_alphanumeric_translation(order) > 300 and first_three_digits == "000" and
+      Regex.match?(@digit_regex, order) and String.to_integer(order) > 300 and
+        first_three_digits == "000" and
           basic != "00000000" ->
         false
 

--- a/test/brcpfcnpj_test.exs
+++ b/test/brcpfcnpj_test.exs
@@ -38,10 +38,13 @@ defmodule BrcpfcnpjTest do
     assert Brcpfcnpj.cpf_valid?(cpf)
   end
 
-  test "should validate correctly a cnpj" do
+  test "should correctly validate a valid cnpj starting with '000'" do
     valid_cnpj = "00012345000165"
-    invalid_cnpj = "00012345030153"
     assert Brcpfcnpj.cnpj_valid?(valid_cnpj)
+  end
+
+  test "should correctly validate a invalid cnpj starting with '000'" do
+    invalid_cnpj = "00012345030153"
     refute Brcpfcnpj.cnpj_valid?(invalid_cnpj)
   end
 

--- a/test/brcpfcnpj_test.exs
+++ b/test/brcpfcnpj_test.exs
@@ -38,6 +38,13 @@ defmodule BrcpfcnpjTest do
     assert Brcpfcnpj.cpf_valid?(cpf)
   end
 
+  test "should validate correctly a cnpj" do
+    valid_cnpj = "00012345000165"
+    invalid_cnpj = "00012345030153"
+    assert Brcpfcnpj.cnpj_valid?(valid_cnpj)
+    refute Brcpfcnpj.cnpj_valid?(invalid_cnpj)
+  end
+
   test "should generate a formatted cnpj" do
     cnpj = Brcpfcnpj.cnpj_generate(true)
 


### PR DESCRIPTION
Fixes #46

The previous validation rule was maintained, but it will only work for CNPJs in the format prior to the alphanumeric format. But it remains unclear whether this is a valid rule or an arbitrary one.