### PR TITLE
fix: reject CPFs with non-digit characters (#56)

### DIFF
--- a/lib/cpfcnpj.ex
+++ b/lib/cpfcnpj.ex
@@ -100,7 +100,7 @@ defmodule Cpfcnpj do
     correct_length? =
       case tp_cpfcnpj do
         {:cpf, _} ->
-          String.length(cpfcnpj) == @cpf_length
+          String.length(cpfcnpj) == @cpf_length and Regex.match?(@digit_regex, cpfcnpj)
 
         {:cnpj, _} ->
           String.length(cpfcnpj) == @cnpj_length

--- a/test/cpf_test.exs
+++ b/test/cpf_test.exs
@@ -42,4 +42,16 @@ defmodule CpfTest do
     assert Brcpfcnpj.cpf_valid?("ABC34501D-84") == false
     assert Brcpfcnpj.cpf_valid?("ABC34501D84") == false
   end
+
+  test "should be invalid when an 11-char string contains letters (issue #56)" do
+    cpfs = ~w{
+      0000invalid 0000INVALID 00000invali 000000nvali 0000000vali
+      00000000ali 000000000li 0000000000i 000invalid0 00invalid00
+      0invalid000 invalid0000 ifoobar0000
+    }
+
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(cpf) == false, "expected #{cpf} to be invalid"
+    end)
+  end
 end


### PR DESCRIPTION
cpf_valid?/1 aceitava como válidas strings de 11 caracteres contendo letras, como "0000invalid". A causa era uma inconsistência entre duas etapas da validação:

- check_number verificava o comprimento removendo apenas . / e -, então as letras contavam para os 11 caracteres;
- type_checker removia todos os não-dígitos antes de calcular os dígitos verificadores, reduzindo "0000invalid" a "0000", cujos DVs ("00") coincidem com os dois últimos caracteres.

O cnpj passou a aceitar caracteres alfanuméricos, mas o cpf continua exclusivamente numérico. O fix aplica @digit_regex ao cpf em check_number, mantendo o cnpj inalterado.

Closes #56