### PR TITLE
valida tamanho também depois de remover invalidos

### DIFF
--- a/lib/cpfcnpj.ex
+++ b/lib/cpfcnpj.ex
@@ -88,8 +88,9 @@ defmodule Cpfcnpj do
   end
 
   # Checks length and if all are equal
-  defp check_number(tp_cpfcnpj) do
-    cpfcnpj = String.replace(elem(tp_cpfcnpj, 1), ~r/[\.\/-]/, "")
+  defp check_number({type, string}) do
+    cpfcnpj = String.replace(string, ~r/[\.\/-]/, "")
+    cpfcnpj_with_only_valid_characters = replace_invalid_characters(type, string)
 
     all_equal? =
       cpfcnpj
@@ -97,17 +98,13 @@ defmodule Cpfcnpj do
       |> String.length()
       |> Kernel.==(0)
 
-    correct_length? =
-      case tp_cpfcnpj do
-        {:cpf, _} ->
-          String.length(cpfcnpj) == @cpf_length
-
-        {:cnpj, _} ->
-          String.length(cpfcnpj) == @cnpj_length
-      end
-
-    correct_length? and not all_equal?
+    correct_length = check_length(type, cpfcnpj)
+    correct_length_only_valid = check_length(type, cpfcnpj_with_only_valid_characters)
+    correct_length and correct_length_only_valid and not all_equal?
   end
+
+  defp check_length(:cpf, cpf), do: String.length(cpf) == @cpf_length
+  defp check_length(:cnpj, cnpj), do: String.length(cnpj) == @cnpj_length
 
   # Checks validation digits
   defp type_checker({type, string}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Brcpfcnpj.Mixfile do
   def project do
     [
       app: :brcpfcnpj,
-      version: "2.0.4",
+      version: "2.1.0",
       elixir: "~> 1.7",
       description: description(),
       package: package(),

--- a/test/cpf_test.exs
+++ b/test/cpf_test.exs
@@ -42,4 +42,16 @@ defmodule CpfTest do
     assert Brcpfcnpj.cpf_valid?("ABC34501D-84") == false
     assert Brcpfcnpj.cpf_valid?("ABC34501D84") == false
   end
+
+  test "should be invalid when an 11-char string contains letters (issue #56)" do
+    cpfs = ~w{
+      0000invalid 0000INVALID 00000invali 000000nvali 0000000vali
+      00000000ali 000000000li 0000000000i 000invalid0 00invalid00
+      0invalid000 invalid0000 ifoobar0000
+    }
+
+    Enum.each(cpfs, fn cpf ->
+      assert Brcpfcnpj.cpf_valid?(cpf) == false, "expected #{cpf} to be invalid"
+    end)
+  end
 end

--- a/test/cpf_test.exs
+++ b/test/cpf_test.exs
@@ -43,7 +43,7 @@ defmodule CpfTest do
     assert Brcpfcnpj.cpf_valid?("ABC34501D84") == false
   end
 
-  test "should be invalid when an 11-char string contains letters (issue #56)" do
+  test "should be invalid when an 11-char string contains letters" do
     cpfs = ~w{
       0000invalid 0000INVALID 00000invali 000000nvali 0000000vali
       00000000ali 000000000li 0000000000i 000invalid0 00invalid00


### PR DESCRIPTION
Valida o tamanho de um cpf ou cnpj tanto antes de remover os caracteres inválidos como depois.

Isso impede que strings que começam com um cpf ou cnpj válido mas que tem caracteres inválidos junto passe
quanto impede que strings do tamanho certo mas com caracteres inválidos no meio passem.